### PR TITLE
more specific test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,7 +21,9 @@ def test_empty_request(dispatcher_live_fixture):
     assert c.status_code == 400
 
      # parameterize this
-    assert sorted(jdata['installed_instruments']) == sorted(['empty', 'empty-async', 'empty-semi-async', 'isgri', 'jemx', 'osa_fake'])
+    assert 'isgri' in jdata['installed_instruments']
+    assert 'jemx' in jdata['installed_instruments']
+    assert 'osa_fake' in jdata['installed_instruments']
 
     assert jdata['debug_mode'] == "yes"
     assert 'dispatcher-config' in jdata['config']


### PR DESCRIPTION
After https://github.com/oda-hub/dispatcher-app/pull/504, certain tests would no longer work. Those are dependent on the dummy instruments provided by the dispatcher. With this we only test for the presence of the instruments provided by this plugin